### PR TITLE
Convert from System.Drawing.Common to SixLabors.ImageSharp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bld/
 
 # Visual Studo 2015 cache/options directory
 .vs/
+.idea/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/src/PdfSharp.Charting/PdfSharp.Charting.csproj
+++ b/src/PdfSharp.Charting/PdfSharp.Charting.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/CLMSUK/PDFsharp</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\PdfSharp\root\VersionInfo.cs">
@@ -119,9 +119,6 @@
     <EmbeddedResource Include="Resources\Messages.restext" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\PdfSharp\PdfSharp.csproj">
-      <Project>{5a6055bc-bf86-4fdd-9f62-0109db7a303b}</Project>
-      <Name>PdfSharp</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\PdfSharp\PdfSharp.csproj" />
   </ItemGroup>
 </Project>

--- a/src/PdfSharp/Drawing/FontFamilyCache.cs
+++ b/src/PdfSharp/Drawing/FontFamilyCache.cs
@@ -33,10 +33,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
-#if CORE || GDI
-using System.Drawing;
-using GdiFontFamily = System.Drawing.FontFamily;
-#endif
 #if WPF
 using System.Windows.Media;
 using System.Windows.Markup;

--- a/src/PdfSharp/Drawing/FontFamilyInternal.cs
+++ b/src/PdfSharp/Drawing/FontFamilyInternal.cs
@@ -31,8 +31,8 @@ using System.Diagnostics;
 using System.Globalization;
 using PdfSharp.Internal;
 #if CORE || GDI
-using System.Drawing;
-using GdiFontFamily = System.Drawing.FontFamily;
+using SixLabors.Fonts;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
 #endif
 #if WPF
 using System.Windows.Media;
@@ -66,7 +66,7 @@ namespace PdfSharp.Drawing
 #if CORE || GDI
             if (createPlatformObjects)
             {
-                _gdiFontFamily = new GdiFontFamily(familyName);
+                _gdiFontFamily = SystemFonts.Get(familyName);
                 _name = _gdiFontFamily.Name;
             }
 #endif

--- a/src/PdfSharp/Drawing/FontHelper.cs
+++ b/src/PdfSharp/Drawing/FontHelper.cs
@@ -32,11 +32,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 #if CORE || GDI
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using GdiFontFamily = System.Drawing.FontFamily;
-using GdiFont = System.Drawing.Font;
-using GdiFontStyle = System.Drawing.FontStyle;
+using SixLabors.Fonts;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
+using GdiFont = SixLabors.Fonts.Font;
+using GdiFontStyle = SixLabors.Fonts.FontStyle;
 #endif
 #if WPF
 using System.Windows;
@@ -130,7 +129,7 @@ namespace PdfSharp.Drawing
             }
 #endif
             // Create ordinary Win32 font.
-            font = new GdiFont(familyName, (float)emSize, style, GraphicsUnit.World);
+            font = new GdiFont(SystemFonts.Get(familyName), (float)emSize, style);
             return font;
         }
 #endif

--- a/src/PdfSharp/Drawing/XBitmapEncoder.cs
+++ b/src/PdfSharp/Drawing/XBitmapEncoder.cs
@@ -34,9 +34,7 @@ using PdfSharp.Internal;
 #if CORE
 #endif
 #if CORE_WITH_GDI
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
+using SixLabors.ImageSharp;
 #endif
 #if GDI
 using System.Drawing;
@@ -110,7 +108,7 @@ namespace PdfSharp.Drawing
             try
             {
                 Lock.EnterGdiPlus();
-                Source._gdiImage.Save(stream, ImageFormat.Png);
+                Source._gdiImage.SaveAsPng(stream);
             }
             finally { Lock.ExitGdiPlus(); }
 #endif

--- a/src/PdfSharp/Drawing/XBitmapImage.cs
+++ b/src/PdfSharp/Drawing/XBitmapImage.cs
@@ -31,9 +31,7 @@
 #endif
 #if CORE_WITH_GDI
 using System;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
+using SixLabors.ImageSharp;
 using PdfSharp.Internal;
 
 #endif
@@ -82,7 +80,7 @@ namespace PdfSharp.Drawing
             {
                 Lock.EnterGdiPlus();
                 // Create a default 24 bit ARGB bitmap.
-                _gdiImage = new Bitmap(width, height);
+                _gdiImage = new Image<SixLabors.ImageSharp.PixelFormats.Abgr32>(width, height);
             }
             finally { Lock.ExitGdiPlus(); }
 #endif

--- a/src/PdfSharp/Drawing/XFont.cs
+++ b/src/PdfSharp/Drawing/XFont.cs
@@ -34,11 +34,9 @@ using System.Diagnostics;
 using System.Globalization;
 using System.ComponentModel;
 #if CORE || GDI
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using GdiFontFamily = System.Drawing.FontFamily;
-using GdiFont = System.Drawing.Font;
-using GdiFontStyle = System.Drawing.FontStyle;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
+using GdiFont = SixLabors.Fonts.Font;
+using GdiFontStyle = SixLabors.Fonts.FontStyle;
 #endif
 #if WPF
 using System.Windows.Markup;
@@ -160,10 +158,10 @@ namespace PdfSharp.Drawing
         /// <param name="pdfOptions">Additional PDF options.</param>
         public XFont(GdiFont font, XPdfFontOptions pdfOptions)
         {
-            if (font.Unit != GraphicsUnit.World)
-                throw new ArgumentException("Font must use GraphicsUnit.World.");
+            //if (font.Unit != GraphicsUnit.World)
+            //    throw new ArgumentException("Font must use GraphicsUnit.World.");
             _gdiFont = font;
-            Debug.Assert(font.Name == font.FontFamily.Name);
+            Debug.Assert(font.Name == font.Family.Name);
             _familyName = font.Name;
             _emSize = font.Size;
             _style = FontStyleFrom(font);
@@ -390,7 +388,7 @@ namespace PdfSharp.Drawing
                 if (_gdiFontFamily != null)
                 {
                     // Create font based on its family.
-                    _gdiFont = new Font(_gdiFontFamily, (float)_emSize, (GdiFontStyle)_style, GraphicsUnit.World);
+                    _gdiFont = new GdiFont(_gdiFontFamily, (float)_emSize, (GdiFontStyle)_style);
                 }
 
                 if (_gdiFont != null)
@@ -400,7 +398,7 @@ namespace PdfSharp.Drawing
                     string name2 = _gdiFont.OriginalFontName;
                     string name3 = _gdiFont.SystemFontName;
 #endif
-                    _familyName = _gdiFont.FontFamily.Name;
+                    _familyName = _gdiFont.Family.Name;
                     // TODO: _glyphTypeface = XGlyphTypeface.GetOrCreateFrom(_gdiFont);
                 }
                 else
@@ -704,7 +702,7 @@ namespace PdfSharp.Drawing
 #if DEBUG
                 double value = Font.GetHeight(graphics._gfx);
 
-                // 2355*(0.3/2048)*96 = 33.11719 
+                // 2355*(0.3/2048)*96 = 33.11719
                 double myValue = CellSpace * (_emSize / (96 * UnitsPerEm)) * 96;
                 myValue = CellSpace * _emSize / UnitsPerEm;
                 //Debug.Assert(value == myValue, "??");
@@ -795,15 +793,15 @@ namespace PdfSharp.Drawing
         {
             get { return _gdiFont; }
         }
-        Font _gdiFont;
+        GdiFont _gdiFont;
 
         internal static XFontStyle FontStyleFrom(GdiFont font)
         {
             return
-              (font.Bold ? XFontStyle.Bold : 0) |
-              (font.Italic ? XFontStyle.Italic : 0) |
-              (font.Strikeout ? XFontStyle.Strikeout : 0) |
-              (font.Underline ? XFontStyle.Underline : 0);
+                (font.IsBold ? XFontStyle.Bold : 0) |
+                (font.IsItalic ? XFontStyle.Italic : 0);
+            //(font.Strikeout ? XFontStyle.Strikeout : 0) |
+            //(font.Underline ? XFontStyle.Underline : 0);
         }
 
 #if true || UseGdiObjects

--- a/src/PdfSharp/Drawing/XFontFamily.cs
+++ b/src/PdfSharp/Drawing/XFontFamily.cs
@@ -29,10 +29,9 @@
 
 using System;
 #if CORE || GDI
-using System.Drawing;
-using GdiFont = System.Drawing.Font;
-using GdiFontFamily = System.Drawing.FontFamily;
-using GdiFontStyle = System.Drawing.FontStyle;
+using GdiFont = SixLabors.Fonts.Font;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
+using GdiFontStyle = SixLabors.Fonts.FontStyle;
 #endif
 #if WPF
 using System.Windows.Media;
@@ -127,7 +126,7 @@ namespace PdfSharp.Drawing
 #if CORE || GDI
         internal static XFontFamily GetOrCreateFromGdi(GdiFont font)
         {
-            FontFamilyInternal fontFamilyInternal = FontFamilyInternal.GetOrCreateFromGdi(font.FontFamily);
+            FontFamilyInternal fontFamilyInternal = FontFamilyInternal.GetOrCreateFromGdi(font.Family);
             return new XFontFamily(fontFamilyInternal);
         }
 #endif
@@ -280,7 +279,7 @@ namespace PdfSharp.Drawing
         }
 
         /// <summary>
-        /// Returns an array that contains all the FontFamily objects available for the specified 
+        /// Returns an array that contains all the FontFamily objects available for the specified
         /// graphics context.
         /// </summary>
         [Obsolete("Use platform API directly.")]

--- a/src/PdfSharp/Drawing/XFontSource.cs
+++ b/src/PdfSharp/Drawing/XFontSource.cs
@@ -31,17 +31,17 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using PdfSharp.Fonts;
 #if CORE || GDI
-using GdiFont = System.Drawing.Font;
-using GdiFontStyle = System.Drawing.FontStyle;
+using GdiFont = SixLabors.Fonts.Font;
+using GdiFontStyle = SixLabors.Fonts.FontStyle;
 #endif
 using PdfSharp.Internal;
 using PdfSharp.Fonts.OpenType;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
+using SixLabors.Fonts;
 
 namespace PdfSharp.Drawing
 {
@@ -52,7 +52,7 @@ namespace PdfSharp.Drawing
     internal class XFontSource
     {
         // Implementation Notes
-        // 
+        //
         // * XFontSource represents a single font (file) in memory.
         // * An XFontSource hold a reference to it OpenTypeFontface.
         // * To prevent large heap fragmentation this class must exists only once.
@@ -80,7 +80,7 @@ namespace PdfSharp.Drawing
             else
             {
                 // Debian
-                searchingPaths.Add("/usr/share/fonts/truetype");
+                searchingPaths.Add("/usr/share/fonts/gnu-free");
                 //searchingPaths.Add("/usr/share/X11/fonts");
                 //searchingPaths.Add("/usr/X11R6/lib/X11/fonts");
                 //searchingPaths.Add("~/.fonts");
@@ -104,13 +104,16 @@ namespace PdfSharp.Drawing
                 {
                     try
                     {
-                        var fontCollection = new System.Drawing.Text.PrivateFontCollection();
-                        fontCollection.AddFontFile(fileName);
-                        var fontName = fontCollection.Families[0].Name;
-                        if (!FontFilePaths.ContainsKey(fontName))
+                        var fontCollection = new FontCollection();
+                        fontCollection.Add(fileName);
+                        foreach (var family in fontCollection.Families)
                         {
-                            FontFilePaths.Add(fontName, fileName);
-                            Debug.WriteLine($"Add font {fontName}: {fileName}");
+                            var fontName = family.Name;
+                            if (!FontFilePaths.ContainsKey(fontName))
+                            {
+                                FontFilePaths.Add(fontName, fileName);
+                                Debug.WriteLine($"Add font {fontName}: {fileName}");
+                            }
                         }
                     }
                     catch (Exception ex)

--- a/src/PdfSharp/Drawing/XFontSource.cs
+++ b/src/PdfSharp/Drawing/XFontSource.cs
@@ -52,7 +52,7 @@ namespace PdfSharp.Drawing
     internal class XFontSource
     {
         // Implementation Notes
-        //
+        // 
         // * XFontSource represents a single font (file) in memory.
         // * An XFontSource hold a reference to it OpenTypeFontface.
         // * To prevent large heap fragmentation this class must exists only once.
@@ -80,7 +80,18 @@ namespace PdfSharp.Drawing
             else
             {
                 // Debian
-                searchingPaths.Add("/usr/share/fonts/gnu-free");
+                if (Directory.Exists("/usr/share/fonts/truetype"))
+                    searchingPaths.Add("/usr/share/fonts/truetype");
+
+                // Fedora
+                if (Directory.Exists("/usr/share/fonts"))
+                {
+                    var fontdirs = Directory.GetDirectories("/usr/share/fonts");
+                    foreach (string fontdir in fontdirs)
+                    {
+                        searchingPaths.Add(fontdir);
+                    }
+                }
                 //searchingPaths.Add("/usr/share/X11/fonts");
                 //searchingPaths.Add("/usr/X11R6/lib/X11/fonts");
                 //searchingPaths.Add("~/.fonts");

--- a/src/PdfSharp/Drawing/XGlyphTypeface.cs
+++ b/src/PdfSharp/Drawing/XGlyphTypeface.cs
@@ -31,11 +31,9 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 #if CORE || GDI
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using GdiFontFamily = System.Drawing.FontFamily;
-using GdiFont = System.Drawing.Font;
-using GdiFontStyle = System.Drawing.FontStyle;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
+using GdiFont = SixLabors.Fonts.Font;
+using GdiFontStyle = SixLabors.Fonts.FontStyle;
 #endif
 #if WPF
 using System.Windows;
@@ -75,8 +73,8 @@ namespace PdfSharp.Drawing
         //
         // * Each XGlyphTypeface can belong to one or more XFont objects.
         // * An XGlyphTypeface hold an XFontFamily.
-        // * XGlyphTypeface hold a reference to an OpenTypeFontface. 
-        // * 
+        // * XGlyphTypeface hold a reference to an OpenTypeFontface.
+        // *
         //
 
         const string KeyPrefix = "tk:";  // "typeface key"
@@ -260,9 +258,9 @@ namespace PdfSharp.Drawing
 
             // Check if styles must be simulated.
             XStyleSimulations styleSimulations = XStyleSimulations.None;
-            if (gdiFont.Bold && !fontSource.Fontface.os2.IsBold)
+            if (gdiFont.IsBold && !fontSource.Fontface.os2.IsBold)
                 styleSimulations |= XStyleSimulations.BoldSimulation;
-            if (gdiFont.Italic && !fontSource.Fontface.os2.IsItalic)
+            if (gdiFont.IsItalic && !fontSource.Fontface.os2.IsItalic)
                 styleSimulations |= XStyleSimulations.ItalicSimulation;
 
             glyphTypeface = new XGlyphTypeface(typefaceKey, fontFamily, fontSource, styleSimulations, gdiFont);
@@ -475,7 +473,7 @@ namespace PdfSharp.Drawing
                 }
             }
             string key = KeyPrefix + familyName.ToLowerInvariant()
-                + (fontResolvingOptions.IsItalic ? "/i" : "/n") // normal / oblique / italic  
+                + (fontResolvingOptions.IsItalic ? "/i" : "/n") // normal / oblique / italic
                 + (fontResolvingOptions.IsBold ? "/700" : "/400") + "/5" // Stretch.Normal
                 + simulationSuffix;
             return key;
@@ -493,13 +491,12 @@ namespace PdfSharp.Drawing
         internal static string ComputeKey(GdiFont gdiFont)
         {
             string name1 = gdiFont.Name;
-            string name2 = gdiFont.OriginalFontName;
-            string name3 = gdiFont.SystemFontName;
+            //string name2 = gdiFont.OriginalFontName;
+            //string name3 = gdiFont.SystemFontName;
 
             string name = name1;
-            GdiFontStyle style = gdiFont.Style;
 
-            string key = KeyPrefix + name.ToLowerInvariant() + ((style & GdiFontStyle.Italic) == GdiFontStyle.Italic ? "/i" : "/n") + ((style & GdiFontStyle.Bold) == GdiFontStyle.Bold ? "/700" : "/400") + "/5"; // Stretch.Normal
+            string key = KeyPrefix + name.ToLowerInvariant() + (gdiFont.IsItalic ? "/i" : "/n") + (gdiFont.IsBold ? "/700" : "/400") + "/5"; // Stretch.Normal
             return key;
         }
 #endif

--- a/src/PdfSharp/Drawing/XImage.cs
+++ b/src/PdfSharp/Drawing/XImage.cs
@@ -34,6 +34,7 @@ using PdfSharp.Pdf;
 #if CORE
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Processing;
 #endif
 #if GDI
 using System.Drawing;
@@ -207,6 +208,7 @@ namespace PdfSharp.Drawing
                 using (Stream file = new FileStream(path, FileMode.Open))
                 {
                     _gdiImage = Image.Load(file, out _gdiImageFormat);
+                    _gdiImage.Mutate(x => x.BackgroundColor(Color.White));
                 }
             }
             finally { Lock.ExitGdiPlus(); }
@@ -251,6 +253,7 @@ namespace PdfSharp.Drawing
             {
                 Lock.EnterGdiPlus();
                 _gdiImage = Image.Load(stream, out _gdiImageFormat);
+                _gdiImage.Mutate(x => x.BackgroundColor(Color.White));
             }
             finally { Lock.ExitGdiPlus(); }
 #endif

--- a/src/PdfSharp/Drawing/XPrivateFontCollection.cs
+++ b/src/PdfSharp/Drawing/XPrivateFontCollection.cs
@@ -34,12 +34,10 @@ using System.IO;
 using System.Runtime.InteropServices;
 using PdfSharp.Fonts;
 #if CORE || GDI
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using GdiFontFamily = System.Drawing.FontFamily;
-using GdiFont = System.Drawing.Font;
-using GdiFontStyle = System.Drawing.FontStyle;
-using GdiPrivateFontCollection = System.Drawing.Text.PrivateFontCollection;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
+using GdiFont = SixLabors.Fonts.Font;
+using GdiFontStyle = SixLabors.Fonts.FontStyle;
+using GdiPrivateFontCollection = SixLabors.Fonts.FontCollection;
 #endif
 #if WPF
 using System.Windows.Markup;
@@ -112,7 +110,7 @@ namespace PdfSharp.Drawing
             // Add to GDI+ PrivateFontCollection
             int length = data.Length;
 
-            // Copy data without unsafe code 
+            // Copy data without unsafe code
             IntPtr ip = Marshal.AllocCoTaskMem(length);
             Marshal.Copy(data, 0, ip, length);
             GetPrivateFontCollection().AddMemoryFont(ip, length);

--- a/src/PdfSharp/Fonts/FontFactory.cs
+++ b/src/PdfSharp/Fonts/FontFactory.cs
@@ -32,9 +32,8 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Text;
 #if CORE || GDI
-using System.Drawing;
-using GdiFontFamily = System.Drawing.FontFamily;
-using GdiFont = System.Drawing.Font;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
+using GdiFont = SixLabors.Fonts.Font;
 #endif
 #if WPF
 using System.Windows;

--- a/src/PdfSharp/Fonts/PlatformFontResolver.cs
+++ b/src/PdfSharp/Fonts/PlatformFontResolver.cs
@@ -30,11 +30,9 @@
 using System;
 using System.Diagnostics;
 #if CORE || GDI
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using GdiFontFamily = System.Drawing.FontFamily;
-using GdiFont = System.Drawing.Font;
-using GdiFontStyle = System.Drawing.FontStyle;
+using GdiFontFamily = SixLabors.Fonts.FontFamily;
+using GdiFont = SixLabors.Fonts.Font;
+using GdiFontStyle = SixLabors.Fonts.FontStyle;
 #endif
 #if WPF
 using System.Windows;
@@ -128,8 +126,8 @@ namespace PdfSharp.Fonts
             else
             {
 #if (CORE || GDI) && !WPF
-                bool mustSimulateBold = gdiFont.Bold && !fontSource.Fontface.os2.IsBold;
-                bool mustSimulateItalic = gdiFont.Italic && !fontSource.Fontface.os2.IsItalic;
+                bool mustSimulateBold = gdiFont.IsBold && !fontSource.Fontface.os2.IsBold;
+                bool mustSimulateItalic = gdiFont.IsItalic && !fontSource.Fontface.os2.IsItalic;
                 fontResolverInfo = new PlatformFontResolverInfo(typefaceKey, mustSimulateBold, mustSimulateItalic, gdiFont);
 #endif
 #if WPF && !SILVERLIGHT

--- a/src/PdfSharp/Fonts/PlatformFontResolverInfo.cs
+++ b/src/PdfSharp/Fonts/PlatformFontResolverInfo.cs
@@ -28,9 +28,8 @@
 #endregion
 
 #if CORE || GDI
-using System.Drawing;
-using GdiFont = System.Drawing.Font;
-
+using SixLabors.Fonts;
+using GdiFont = SixLabors.Fonts.Font;
 #endif
 #if WPF
 using System.Windows.Media;

--- a/src/PdfSharp/Pdf.Advanced/PdfImage.cs
+++ b/src/PdfSharp/Pdf.Advanced/PdfImage.cs
@@ -33,7 +33,6 @@ using System.Diagnostics;
 using System.IO;
 #if CORE
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 #endif
 #if GDI
 using System.Drawing.Imaging;

--- a/src/PdfSharp/Pdf.Advanced/PdfImage.cs
+++ b/src/PdfSharp/Pdf.Advanced/PdfImage.cs
@@ -32,7 +32,8 @@ using System;
 using System.Diagnostics;
 using System.IO;
 #if CORE
-using System.Drawing.Imaging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 #endif
 #if GDI
 using System.Drawing.Imaging;
@@ -314,7 +315,7 @@ namespace PdfSharp.Pdf.Advanced
 #if CORE_WITH_GDI
                         // No stream, no filename, get image data.
                         // Save the image to a memory stream.
-                        _image._gdiImage.Save(memory, ImageFormat.Jpeg);
+                        _image._gdiImage.SaveAsJpeg(memory);
 #endif
                     }
                 }
@@ -414,7 +415,7 @@ namespace PdfSharp.Pdf.Advanced
 #if CORE_WITH_GDI
             if (_image._importedImage == null)
             {
-                if ((_image._gdiImage.Flags & ((int)ImageFlags.ColorSpaceCmyk | (int)ImageFlags.ColorSpaceYcck)) != 0)
+                /*if ((_image._gdiImage.Flags & ((int)ImageFlags.ColorSpaceCmyk | (int)ImageFlags.ColorSpaceYcck)) != 0)
                 {
                     // TODO: Test with CMYK JPEG files (so far I only found ImageFlags.ColorSpaceYcck JPEG files ...)
                     Elements[Keys.ColorSpace] = new PdfName("/DeviceCMYK");
@@ -425,7 +426,7 @@ namespace PdfSharp.Pdf.Advanced
                 {
                     Elements[Keys.ColorSpace] = new PdfName("/DeviceGray");
                 }
-                else
+                else*/
                 {
                     Elements[Keys.ColorSpace] = new PdfName("/DeviceRGB");
                 }
@@ -511,6 +512,8 @@ namespace PdfSharp.Pdf.Advanced
 #endif
 
 #if (CORE_WITH_GDI || GDI) && !WPF
+            ReadTrueColorMemoryBitmap(3, 8, false);
+            /*
             switch (_image._gdiImage.PixelFormat)
             {
                 case PixelFormat.Format24bppRgb:
@@ -543,7 +546,7 @@ namespace PdfSharp.Pdf.Advanced
           image.image.Save("$$$.bmp", ImageFormat.Bmp);
 #endif
                     throw new NotImplementedException("Image format not supported.");
-            }
+            }*/
 #endif
 #if WPF // && !GDI
 #if !SILVERLIGHT
@@ -836,7 +839,7 @@ namespace PdfSharp.Pdf.Advanced
             int pdfVersion = Owner.Version;
             MemoryStream memory = new MemoryStream();
 #if CORE_WITH_GDI
-            _image._gdiImage.Save(memory, ImageFormat.Bmp);
+            _image._gdiImage.SaveAsBmp(memory);
 #endif
 #if GDI
             _image._gdiImage.Save(memory, ImageFormat.Bmp);
@@ -1034,7 +1037,7 @@ namespace PdfSharp.Pdf.Advanced
 
             MemoryStream memory = new MemoryStream();
 #if CORE_WITH_GDI
-            _image._gdiImage.Save(memory, ImageFormat.Bmp);
+            _image._gdiImage.SaveAsBmp(memory);
 #endif
 #if GDI
             _image._gdiImage.Save(memory, ImageFormat.Bmp);

--- a/src/PdfSharp/PdfSharp.csproj
+++ b/src/PdfSharp/PdfSharp.csproj
@@ -392,7 +392,8 @@
     <Folder Include="SharpZipLib\SharpZip\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta16" />
     <PackageReference Include="System.Resources.Extensions" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Replacing System.Drawing.Common with SixLabors.ImageSharp. Since System.Drawing.Common is deprecated.